### PR TITLE
fix: add LTX-2.3 to download script + validate num_frames in standard pipeline

### DIFF
--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -38,6 +38,15 @@ console = Console()
 
 # Weight definitions
 WEIGHTS = {
+    "2.3-distilled": {
+        "name": "LTX-2.3 22B Distilled",
+        "description": "Latest model (22B params, 8 steps) - Recommended",
+        "repo": "Lightricks/LTX-2",
+        "filename": "ltx-2.3-22b-distilled.safetensors",
+        "local_path": "weights/ltx-2.3/ltx-2.3-22b-distilled.safetensors",
+        "size": "~46GB",
+        "required": True,
+    },
     "distilled": {
         "name": "LTX-2 19B Distilled",
         "description": "Fast generation (8 steps), recommended for most users",

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1046,6 +1046,13 @@ def generate_video(
     # Set seed
     mx.random.seed(seed)
 
+    # Validate num_frames constraint (must be 8k + 1 for VAE temporal compression)
+    if num_frames % 8 != 1:
+        nearest_valid = ((num_frames - 1 + 4) // 8) * 8 + 1  # Round to nearest valid
+        print(f"  WARNING: num_frames must be 8*k + 1 (e.g., 1, 9, 17, 25, ..., 97, 121).")
+        print(f"  Got {num_frames}, adjusting to {nearest_valid}.")
+        num_frames = nearest_valid
+
     # Compute latent dimensions
     # VAE: 32x spatial, 8x temporal compression
     latent_height = height // 32


### PR DESCRIPTION
## Summary

Two fixes that improve the new-user experience and prevent silent output issues.

### 1. Download script missing LTX-2.3

The README recommends LTX-2.3 (22B Distilled) as the latest and best model, but `scripts/download_weights.py` only contains LTX-2.0 entries. New users running `uv run scripts/download_weights.py` get the older 2.0 model without realizing 2.3 exists.

**Fix:** Added `2.3-distilled` entry to the `WEIGHTS` dict pointing to `ltx-2.3-22b-distilled.safetensors`.

### 2. No `num_frames` validation in standard pipeline

The two-stage configs (`OneStageCFGConfig`, `TwoStageCFGConfig`) validate that `num_frames % 8 == 1` in their `__post_init__`, but the standard pipeline path (used by `text-to-video` and `distilled` — the most common use cases) skips this check entirely.

A user running `--frames 100` silently gets 97 output frames because `(100 - 1) // 8 + 1 = 13` latent frames decode to 97 — no warning, no error.

**Fix:** Added validation + auto-adjustment at the top of `generate_video()`, consistent with how resolution is already handled for two-stage pipelines. Prints a warning and rounds to the nearest valid frame count.