### PR TITLE
fix: audio/video sync, fps consistency, audio position precision (echo issue), and --duration flag

### DIFF
--- a/LTX_2_MLX/conditioning/tools.py
+++ b/LTX_2_MLX/conditioning/tools.py
@@ -214,7 +214,7 @@ class AudioLatentTools:
             LatentState(
                 latent=initial_latent,
                 denoise_mask=denoise_mask,
-                positions=latent_coords.astype(dtype),
+                positions=latent_coords, # keep float32; downcasting to fp16 causes echo artifacts
                 clean_latent=clean_latent,
             )
         )

--- a/LTX_2_MLX/pipelines/a2vid_two_stage.py
+++ b/LTX_2_MLX/pipelines/a2vid_two_stage.py
@@ -43,6 +43,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -57,7 +58,7 @@ class A2VidConfig:
     num_inference_steps: int = 30
     cfg_scale: float = 3.0
     seed: int = 42
-    fps: float = 25.0
+    fps: float = NATIVE_FPS
 
     # LoRA for stage 2 refinement
     distilled_lora_config: Optional[LoRAConfig] = None

--- a/LTX_2_MLX/pipelines/distilled.py
+++ b/LTX_2_MLX/pipelines/distilled.py
@@ -42,6 +42,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -56,7 +57,7 @@ class DistilledConfig:
 
     # Generation parameters
     seed: int = 42
-    fps: float = 25.0  # Match PyTorch default frame_rate
+    fps: float = NATIVE_FPS
 
     # Tiling for VAE decoding
     tiling_config: Optional[TilingConfig] = None

--- a/LTX_2_MLX/pipelines/ic_lora.py
+++ b/LTX_2_MLX/pipelines/ic_lora.py
@@ -43,6 +43,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -124,7 +125,7 @@ def preprocess_canny(
 def _save_control_video(
     video_np: np.ndarray,
     output_path: str,
-    fps: float = 24.0,
+    fps: float = NATIVE_FPS,
 ) -> None:
     """Save a control video to disk for debugging/visualization."""
     try:
@@ -251,7 +252,7 @@ class ICLoraConfig:
     stage_1_steps: int = 7  # Distilled model steps
     stage_2_steps: int = 3  # Refinement steps
     seed: int = 42
-    fps: float = 24.0
+    fps: float = NATIVE_FPS
 
     # Tiling
     tiling_config: Optional[TilingConfig] = None

--- a/LTX_2_MLX/pipelines/keyframe_interpolation.py
+++ b/LTX_2_MLX/pipelines/keyframe_interpolation.py
@@ -39,6 +39,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -55,7 +56,7 @@ class KeyframeInterpolationConfig:
     num_inference_steps: int = 30
     cfg_scale: float = 7.5
     seed: int = 42
-    fps: float = 24.0
+    fps: float = NATIVE_FPS
 
     # Two-stage parameters
     use_two_stage: bool = True

--- a/LTX_2_MLX/pipelines/one_stage.py
+++ b/LTX_2_MLX/pipelines/one_stage.py
@@ -46,6 +46,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -60,7 +61,7 @@ class OneStageCFGConfig:
 
     # Generation parameters
     seed: int = 42
-    fps: float = 24.0  # Restore MLX known-good short-clip baseline
+    fps: float = NATIVE_FPS
     num_inference_steps: int = 30
 
     # CFG parameters (matching LTX-2.3 reference defaults)

--- a/LTX_2_MLX/pipelines/ti2vid_hq.py
+++ b/LTX_2_MLX/pipelines/ti2vid_hq.py
@@ -46,6 +46,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -62,7 +63,7 @@ class TI2VidHQConfig:
     audio_cfg_scale: float = 7.0
     guidance_rescale: float = 0.45
     seed: int = 42
-    fps: float = 25.0
+    fps: float = NATIVE_FPS
 
     # LoRA for stage 2 refinement
     distilled_lora_config: Optional[LoRAConfig] = None

--- a/LTX_2_MLX/pipelines/two_stage.py
+++ b/LTX_2_MLX/pipelines/two_stage.py
@@ -49,6 +49,7 @@ from ..types import (
     LatentState,
     VideoLatentShape,
     VideoPixelShape,
+    NATIVE_FPS
 )
 
 
@@ -96,7 +97,7 @@ class TwoStageCFGConfig:
 
     # Generation parameters
     seed: int = 42
-    fps: float = 25.0  # Match PyTorch default frame_rate for audio latent calculations
+    fps: float = NATIVE_FPS
     num_inference_steps: int = 30
 
     # Guidance parameters (for stage 1) — matching Reddit/ComfyUI working config

--- a/LTX_2_MLX/types.py
+++ b/LTX_2_MLX/types.py
@@ -6,6 +6,9 @@ from typing import NamedTuple, Tuple
 
 import mlx.core as mx
 
+# LTX-2 native frame rate. Matches frame_rate in the official Lightricks PipelineParams.
+# See: https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py
+NATIVE_FPS: int = 24
 
 class VideoPixelShape(NamedTuple):
     """
@@ -17,7 +20,7 @@ class VideoPixelShape(NamedTuple):
     frames: int
     height: int
     width: int
-    fps: float = 25.0
+    fps: float
 
 
 class SpatioTemporalScaleFactors(NamedTuple):
@@ -140,7 +143,7 @@ class AudioLatentShape(NamedTuple):
         return AudioLatentShape(
             batch=batch,
             channels=channels,
-            frames=round(duration * latents_per_second),
+            frames=math.ceil(duration * latents_per_second),  # ceil ensures audio covers full video duration; round() can drop the last frame
             mel_bins=mel_bins,
         )
 

--- a/LTX_2_MLX/types.py
+++ b/LTX_2_MLX/types.py
@@ -8,7 +8,7 @@ import mlx.core as mx
 
 # LTX-2 native frame rate. Matches frame_rate in the official Lightricks PipelineParams.
 # See: https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py
-NATIVE_FPS: int = 24
+NATIVE_FPS: float = 24.0
 
 class VideoPixelShape(NamedTuple):
     """

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -36,7 +36,7 @@ from LTX_2_MLX.model.video_vae import VideoDecoder, NormLayerType
 from LTX_2_MLX.components import DISTILLED_SIGMA_VALUES, VideoLatentPatchifier, get_sigma_schedule
 from LTX_2_MLX.components.guiders import LtxAPGGuider, LegacyStatefulAPGGuider, STGGuider
 from LTX_2_MLX.components.perturbations import create_batched_stg_config
-from LTX_2_MLX.types import VideoLatentShape
+from LTX_2_MLX.types import VideoLatentShape, NATIVE_FPS
 from LTX_2_MLX.loader import load_transformer_weights, load_av_transformer_weights, LoRAConfig
 from LTX_2_MLX.loader.lora_loader import fuse_lora_into_weights
 from mlx.utils import tree_flatten
@@ -1381,7 +1381,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=24.0,
+            fps=NATIVE_FPS,
             num_inference_steps=steps_stage1,
             cfg_scale=cfg_stage1 if cfg_stage1 is not None else cfg_scale,
             guidance_rescale=guidance_rescale,
@@ -1498,7 +1498,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=24.0,
+            fps=NATIVE_FPS,
             stage_1_steps=num_steps,
             dtype=compute_dtype,
         )
@@ -1608,7 +1608,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=24.0,
+            fps=NATIVE_FPS,
             num_inference_steps=num_steps,
             cfg_scale=cfg_scale,
             dtype=compute_dtype,
@@ -1692,14 +1692,13 @@ def generate_video(
         )
 
         # Create config with audio enabled
-        # NOTE: fps=25.0 matches PyTorch's default frame_rate for audio latent calculations
         # LTX-2.3 reference: video_cfg=3.0, audio_cfg=7.0, rescale=0.7
         av_config = OneStageCFGConfig(
             height=height,
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=25.0,  # Required for AV: matches PyTorch frame_rate for audio latent shape
+            fps=NATIVE_FPS,
             num_inference_steps=num_steps,
             cfg_scale=cfg_scale,
             audio_cfg_scale=audio_cfg_scale if audio_cfg_scale is not None else (1.0 if model_variant == "distilled" else 7.0),
@@ -1820,7 +1819,7 @@ def generate_video(
                 causal_fix=True,
             ).astype(mx.float32)
             # Convert temporal positions from frames to seconds
-            fps = 24.0
+            fps = NATIVE_FPS
             temporal_positions = positions[:, 0:1, ...] / fps
             other_positions = positions[:, 1:, ...]
             positions = mx.concatenate([temporal_positions, other_positions], axis=1)
@@ -2150,20 +2149,18 @@ def generate_video(
         print("\nNote: VAE decoder was not loaded - output is placeholder visualization.")
 
 
-def save_video(frames: list, output_path: str, fps: int = 24, speed: float = 1.0):
+def save_video(frames: list, output_path: str, fps: int = NATIVE_FPS, speed: float = 1.0):
     """Save frames as video using ffmpeg with optional interpolation and speed adjustment.
 
     Args:
         frames: List of frame arrays (H, W, C) in uint8.
         output_path: Output video file path.
-        fps: Target output frame rate. If >24, uses motion interpolation.
+        fps: Target output frame rate. Values above NATIVE_FPS use motion interpolation.
         speed: Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast).
     """
     import subprocess
     import tempfile
     from PIL import Image
-
-    NATIVE_FPS = 24  # Model generates motion at 24fps
 
     # Create temp directory for frames
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -2231,7 +2228,7 @@ def save_video_with_audio(
     frames: list,
     audio_waveform: mx.array,
     output_path: str,
-    fps: int = 24,
+    fps: int = NATIVE_FPS,
     speed: float = 1.0,
     audio_sample_rate: int = 24000,
 ):
@@ -2241,7 +2238,7 @@ def save_video_with_audio(
         frames: List of frame arrays (H, W, C) in uint8.
         audio_waveform: Audio waveform tensor (B, 2, samples).
         output_path: Output video file path.
-        fps: Target output frame rate. If >24, uses motion interpolation.
+        fps: Target output frame rate. Values above NATIVE_FPS use motion interpolation.
         speed: Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast).
         audio_sample_rate: Audio sample rate in Hz.
     """
@@ -2251,8 +2248,6 @@ def save_video_with_audio(
     import tempfile
     import wave
     from PIL import Image
-
-    NATIVE_FPS = 24  # Model generates motion at 24fps
 
     # Create temp directory for frames and audio
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -2325,7 +2320,7 @@ def save_video_with_audio(
         print("\n  Encoding video with audio...")
         cmd = [
             "ffmpeg", "-y",
-            "-framerate", str(NATIVE_FPS),  # Input is always at native 24fps
+            "-framerate", str(NATIVE_FPS),  # Input is always at native fps
             "-i", os.path.join(tmpdir, "frame_%04d.png"),
             "-i", audio_path,
         ]
@@ -2373,7 +2368,7 @@ def main():
     parser.add_argument("--steps-stage2", type=int, default=3, help="Stage 2 refinement steps for two-stage pipeline")
     parser.add_argument("--cfg-stage1", type=float, default=None, help="Stage 1 CFG (defaults to --cfg value)")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
-    parser.add_argument("--fps", type=int, default=24, help="Output video frame rate (default: 24). If >24, uses frame interpolation.")
+    parser.add_argument("--fps", type=int, default=NATIVE_FPS, help=f"Output video frame rate (default: {NATIVE_FPS}). If >{NATIVE_FPS}, uses frame interpolation.")
     parser.add_argument("--speed", type=float, default=1.0, help="Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast)")
     parser.add_argument("--output", type=str, default="outputs/output.mp4", help="Output path")
     parser.add_argument(

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -4,6 +4,7 @@
 import argparse
 import gc
 import os
+import math
 import sys
 from pathlib import Path
 
@@ -930,11 +931,42 @@ def euler_step_x0(
     return sample.astype(mx.float32) + velocity.astype(mx.float32) * dt
 
 
+def next_valid_frame_count(frame_count: int) -> int:
+    """Round up to the next LTX-valid frame count: 8*k + 1."""
+    if frame_count <= 1:
+        return 1
+    return ((frame_count - 1 + 7) // 8) * 8 + 1
+
+
+def resolve_num_frames(
+    *,
+    num_frames: int,
+    duration_seconds: float | None,
+    fps: float,
+) -> int:
+    """Resolve frame count from explicit frames or duration.
+
+    If duration is provided, ceil() is used so the generated video covers at
+    least the requested duration, then the result is rounded up to 8*k + 1.
+    """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}")
+
+    if duration_seconds is None:
+        return num_frames
+
+    if duration_seconds <= 0:
+        raise ValueError(f"duration must be positive, got {duration_seconds}")
+
+    requested_frames = math.ceil(duration_seconds * fps)
+    return next_valid_frame_count(requested_frames)
+
+
 def generate_video(
     prompt: str,
     height: int = 480,
     width: int = 704,
-    num_frames: int = 97,  # 12 seconds at 8fps after VAE (97 = 1 + 12*8)
+    num_frames: int = 97,  # ~32s at 24fps (97 latent frames → 769 pixel frames via 8x VAE temporal compression)
     num_steps: int = 7,  # Distilled model uses 7 steps
     cfg_scale: float = 5.0,  # Updated default for better semantic quality
     guidance_rescale: float = 0.7,  # Rescale CFG output to prevent variance explosion
@@ -985,7 +1017,7 @@ def generate_video(
     control_strength: float = 0.95,
     save_control: bool = False,
     ge_gamma: float = 0.0,
-    output_fps: int = 24,
+    output_fps: float = NATIVE_FPS,
     output_speed: float = 1.0,
     # IC-LoRA and Keyframe Interpolation
     keyframes: list = None,
@@ -1381,7 +1413,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=NATIVE_FPS,
+            fps=output_fps,
             num_inference_steps=steps_stage1,
             cfg_scale=cfg_stage1 if cfg_stage1 is not None else cfg_scale,
             guidance_rescale=guidance_rescale,
@@ -1498,7 +1530,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=NATIVE_FPS,
+            fps=output_fps,
             stage_1_steps=num_steps,
             dtype=compute_dtype,
         )
@@ -1608,7 +1640,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=NATIVE_FPS,
+            fps=output_fps,
             num_inference_steps=num_steps,
             cfg_scale=cfg_scale,
             dtype=compute_dtype,
@@ -1698,7 +1730,7 @@ def generate_video(
             width=width,
             num_frames=num_frames,
             seed=seed,
-            fps=NATIVE_FPS,
+            fps=output_fps,
             num_inference_steps=num_steps,
             cfg_scale=cfg_scale,
             audio_cfg_scale=audio_cfg_scale if audio_cfg_scale is not None else (1.0 if model_variant == "distilled" else 7.0),
@@ -1819,7 +1851,7 @@ def generate_video(
                 causal_fix=True,
             ).astype(mx.float32)
             # Convert temporal positions from frames to seconds
-            fps = NATIVE_FPS
+            fps = output_fps
             temporal_positions = positions[:, 0:1, ...] / fps
             other_positions = positions[:, 1:, ...]
             positions = mx.concatenate([temporal_positions, other_positions], axis=1)
@@ -2149,13 +2181,13 @@ def generate_video(
         print("\nNote: VAE decoder was not loaded - output is placeholder visualization.")
 
 
-def save_video(frames: list, output_path: str, fps: int = NATIVE_FPS, speed: float = 1.0):
-    """Save frames as video using ffmpeg with optional interpolation and speed adjustment.
+def save_video(frames: list, output_path: str, fps: float = NATIVE_FPS, speed: float = 1.0):
+    """Save frames as video using ffmpeg with optional speed adjustment.
 
     Args:
         frames: List of frame arrays (H, W, C) in uint8.
         output_path: Output video file path.
-        fps: Target output frame rate. Values above NATIVE_FPS use motion interpolation.
+        fps: Generation and output frame rate.
         speed: Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast).
     """
     import subprocess
@@ -2178,26 +2210,17 @@ def save_video(frames: list, output_path: str, fps: int = NATIVE_FPS, speed: flo
         # Build ffmpeg filter chain
         filters = []
 
-        # Speed adjustment (applied first, before interpolation)
+        # Speed adjustment
         # setpts: lower value = faster, higher value = slower
         if speed != 1.0:
             # speed=2.0 means 2x faster, so PTS should be halved
             pts_multiplier = 1.0 / speed
             filters.append(f"setpts={pts_multiplier}*PTS")
-
-        # Frame interpolation if target fps > native
-        if fps > NATIVE_FPS:
-            # minterpolate creates smooth intermediate frames
-            # mi_mode=mci: motion compensated interpolation
-            # mc_mode=aobmc: adaptive overlapped block motion compensation
-            # me_mode=bidir: bidirectional motion estimation
-            filters.append(f"minterpolate=fps={fps}:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1")
-
         # Build ffmpeg command
         print("\n  Encoding video...")
         cmd = [
             "ffmpeg", "-y",
-            "-framerate", str(NATIVE_FPS),  # Input is always at native 24fps
+            "-framerate", str(fps),  # Input frame cadence matches generation fps
             "-i", os.path.join(tmpdir, "frame_%04d.png"),
         ]
 
@@ -2205,9 +2228,7 @@ def save_video(frames: list, output_path: str, fps: int = NATIVE_FPS, speed: flo
         if filters:
             filter_str = ",".join(filters)
             cmd.extend(["-vf", filter_str])
-            if fps > NATIVE_FPS:
-                print(f"  Interpolating {NATIVE_FPS}fps → {fps}fps (speed: {speed}x)")
-            elif speed != 1.0:
+            if speed != 1.0:
                 print(f"  Applying speed: {speed}x")
 
         cmd.extend([
@@ -2228,17 +2249,17 @@ def save_video_with_audio(
     frames: list,
     audio_waveform: mx.array,
     output_path: str,
-    fps: int = NATIVE_FPS,
+    fps: float = NATIVE_FPS,
     speed: float = 1.0,
     audio_sample_rate: int = 24000,
 ):
-    """Save frames as video with audio using ffmpeg with optional interpolation and speed.
+    """Save frames as video with audio using ffmpeg with optional speed adjustment.
 
     Args:
         frames: List of frame arrays (H, W, C) in uint8.
         audio_waveform: Audio waveform tensor (B, 2, samples).
         output_path: Output video file path.
-        fps: Target output frame rate. Values above NATIVE_FPS use motion interpolation.
+        fps: Generation and output frame rate.
         speed: Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast).
         audio_sample_rate: Audio sample rate in Hz.
     """
@@ -2293,14 +2314,10 @@ def save_video_with_audio(
         # Build video filter chain
         video_filters = []
 
-        # Speed adjustment for video (applied first, before interpolation)
+        # Speed adjustment for video
         if speed != 1.0:
             pts_multiplier = 1.0 / speed
             video_filters.append(f"setpts={pts_multiplier}*PTS")
-
-        # Frame interpolation if target fps > native
-        if fps > NATIVE_FPS:
-            video_filters.append(f"minterpolate=fps={fps}:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1")
 
         # Build audio filter chain for speed adjustment
         # atempo filter range is 0.5-2.0, so chain multiple for extreme speeds
@@ -2320,7 +2337,7 @@ def save_video_with_audio(
         print("\n  Encoding video with audio...")
         cmd = [
             "ffmpeg", "-y",
-            "-framerate", str(NATIVE_FPS),  # Input is always at native fps
+            "-framerate", str(fps),  # Input frame cadence matches generation fps
             "-i", os.path.join(tmpdir, "frame_%04d.png"),
             "-i", audio_path,
         ]
@@ -2328,9 +2345,7 @@ def save_video_with_audio(
         # Add video filter chain if needed
         if video_filters:
             cmd.extend(["-vf", ",".join(video_filters)])
-            if fps > NATIVE_FPS:
-                print(f"  Interpolating {NATIVE_FPS}fps → {fps}fps (speed: {speed}x)")
-            elif speed != 1.0:
+            if speed != 1.0:
                 print(f"  Applying speed: {speed}x")
 
         # Add audio filter chain if needed
@@ -2361,6 +2376,7 @@ def main():
     parser.add_argument("--height", type=int, default=480, help="Video height")
     parser.add_argument("--width", type=int, default=704, help="Video width")
     parser.add_argument("--frames", type=int, default=97, help="Number of frames")
+    parser.add_argument("--duration", type=float, default=None, help="Duration in seconds. Overrides --frames and rounds up to the next valid 8*k+1 frame count.")
     parser.add_argument("--steps", type=int, default=8, help="Denoising steps (8 for distilled, 15+ for two-stage)")
     parser.add_argument("--cfg", type=float, default=5.0, help="CFG scale (default 5.0 for better semantic quality)")
     parser.add_argument("--guidance-rescale", type=float, default=0.7, help="Guidance rescale factor (0.0=off, 0.7=default, 1.0=full)")
@@ -2368,7 +2384,7 @@ def main():
     parser.add_argument("--steps-stage2", type=int, default=3, help="Stage 2 refinement steps for two-stage pipeline")
     parser.add_argument("--cfg-stage1", type=float, default=None, help="Stage 1 CFG (defaults to --cfg value)")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
-    parser.add_argument("--fps", type=int, default=NATIVE_FPS, help=f"Output video frame rate (default: {NATIVE_FPS}). If >{NATIVE_FPS}, uses frame interpolation.")
+    parser.add_argument("--fps", type=float, default=NATIVE_FPS, help=f"Generation and output frame rate (default: {NATIVE_FPS}).")
     parser.add_argument("--speed", type=float, default=1.0, help="Playback speed multiplier (0.5=slow-mo, 1.0=normal, 2.0=fast)")
     parser.add_argument("--output", type=str, default="outputs/output.mp4", help="Output path")
     parser.add_argument(
@@ -2650,6 +2666,17 @@ def main():
             args.weights = args.weights.replace(".safetensors", "-fp8.safetensors")
             print(f"Using FP8 weights: {args.weights}")
 
+    resolved_num_frames = resolve_num_frames(
+        num_frames=args.frames,
+        duration_seconds=args.duration,
+        fps=args.fps,
+    )
+    if args.duration is not None:
+        print(
+            f"Resolved duration {args.duration}s at {args.fps}fps "
+            f"to {resolved_num_frames} frames"
+        )
+
     generate_video(
         distilled_lora=args.distilled_lora,
         distilled_lora_scale=args.distilled_lora_scale,
@@ -2657,7 +2684,7 @@ def main():
         prompt=args.prompt,
         height=args.height,
         width=args.width,
-        num_frames=args.frames,
+        num_frames=resolved_num_frames,
         num_steps=args.steps,
         cfg_scale=args.cfg,
         guidance_rescale=getattr(args, 'guidance_rescale', 0.7),

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -13,7 +13,7 @@ from LTX_2_MLX.components.patchifiers import VideoLatentPatchifier
 from LTX_2_MLX.conditioning.keyframe import VideoConditionByKeyframeIndex
 from LTX_2_MLX.conditioning.latent import VideoConditionByLatentIndex, ConditioningError
 from LTX_2_MLX.conditioning.tools import VideoLatentTools
-from LTX_2_MLX.types import LatentState, VideoLatentShape
+from LTX_2_MLX.types import LatentState, VideoLatentShape, NATIVE_FPS
 
 
 class TestVideoConditionByLatentIndex:
@@ -35,7 +35,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         # Create initial state
@@ -71,7 +71,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -116,7 +116,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -148,7 +148,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -179,7 +179,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -210,7 +210,7 @@ class TestVideoConditionByLatentIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -255,7 +255,7 @@ class TestVideoConditionByKeyframeIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -289,7 +289,7 @@ class TestVideoConditionByKeyframeIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -331,7 +331,7 @@ class TestVideoConditionByKeyframeIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -363,7 +363,7 @@ class TestVideoConditionByKeyframeIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         initial_state = tools.create_initial_state(dtype=mx.float32)
@@ -395,7 +395,7 @@ class TestVideoConditionByKeyframeIndex:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         state = tools.create_initial_state(dtype=mx.float32)
@@ -443,7 +443,7 @@ class TestVideoLatentTools:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         state = tools.create_initial_state(dtype=mx.float32)
@@ -471,7 +471,7 @@ class TestVideoLatentTools:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         # Create custom latent
@@ -496,7 +496,7 @@ class TestVideoLatentTools:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         # Create state and add keyframe
@@ -530,7 +530,7 @@ class TestVideoLatentTools:
         tools = VideoLatentTools(
             patchifier=patchifier,
             target_shape=target_shape,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         state = tools.create_initial_state(dtype=mx.float32)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -21,7 +21,7 @@ from LTX_2_MLX.pipelines.common import (
     post_process_latent,
     timesteps_from_mask,
 )
-from LTX_2_MLX.types import VideoLatentShape
+from LTX_2_MLX.types import VideoLatentShape, NATIVE_FPS
 
 
 # ============================================================================
@@ -87,7 +87,7 @@ class TestDistilledConfig:
         assert config.width == 768
         assert config.num_frames == 97
         assert config.seed == 42
-        assert config.fps == 24.0
+        assert config.fps == NATIVE_FPS
 
     def test_invalid_frame_count_raises(self):
         """Test invalid frame counts raise ValueError."""
@@ -278,7 +278,7 @@ class TestVideoLatentShape:
             frames=97,
             height=480,
             width=704,
-            fps=24.0,
+            fps=NATIVE_FPS,
         )
 
         latent_shape = VideoLatentShape.from_pixel_shape(


### PR DESCRIPTION
**Summary**

This PR fixes several audio/video sync issues, standardizes fps handling across the codebase, and adds a `--duration` flag for convenience.

**Changes**

*fix: preserve float32 precision for audio latent positions (`LTX_2_MLX/conditioning/tools.py`)*
- Removing the `.astype(dtype)` cast on audio latent position coordinates prevents fp16 precision loss that caused audible echo/comb artifacts in generated audio.

*fix: correct fps default from 25.0 to 24.0, centralize as `NATIVE_FPS` (`LTX_2_MLX/types.py`, all pipeline configs)*
- fps was inconsistently hardcoded as 25.0 in some pipeline configs and 24.0 in others. Centralized as `NATIVE_FPS: float = 24.0`, matching the official Lightricks reference implementation: https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py
- Also fixes `AudioLatentShape` to use `math.ceil()` instead of `round()` — `round()` can produce audio slightly shorter than the video, causing ffmpeg `-shortest` to drop the last frame.
- Both fixes improve audio/video lip sync.

*feat: add `--duration` flag and fix fps handling (`scripts/generate.py`)*
- `--duration` specifies clip length in seconds and automatically resolves to the nearest valid `8*k+1` frame count.
- `output_fps` changed from `int` to `float`, defaulting to `NATIVE_FPS`, and passed through to all pipeline configs instead of being hardcoded.
- Removed motion interpolation (`minterpolate`) from save functions — fps now directly controls the generation rate.

**Example output**

30s clip at 288×512, `--fps 24 --duration 30`, `ltx-2.3-22b-distilled-1.1`, M1 Max 64GB:

https://github.com/user-attachments/assets/2f943e19-f5b7-448b-a6e2-0e60130967dc

```bash
python scripts/generate.py \
"Live-action footage shot on a consumer camera, cozy indoor setting, shallow depth of field. A small marble black kitten with swirling black and dark grey fur, bright yellow-green eyes, tiny pink nose, and oversized ears sits on a living room couch. Warm afternoon light filters through nearby curtains. The kitten looks directly into the camera and says, \"I have been awake for nineteen hours. Do I sleep? No. Do I rest? No. I sit here and I think about the vacuum cleaner. It was loud yesterday. It will be loud again. I don't know when. That's the thing. I never know when.\" The kitten glances to the left, then snaps back to the camera and says, \"You probably think I'm being dramatic. The vacuum cleaner is literally called a vacuum. It creates a void. A void, in my home. And everyone just acts like that's fine.\" The kitten licks its paw once, stares blankly for a moment, then says, \"Anyway I'm going to knock something off the counter later. I haven't decided what yet. I'm keeping my options open.\" Natural indoor ambience, soft room tone, faint ticking clock, clear kitten voice. Camera is handheld, mostly static with slight natural sway, warm soft shadows, slightly underexposed cozy indoor look." \
    --weights /Users/Shared/huggingface/hub/models--Lightricks--LTX-2.3/snapshots/76730e634e70a28f4e8d51f5e29c08e40e2d8e74/ltx-2.3-22b-distilled-1.1.safetensors \
    --gemma-path /Users/Shared/huggingface/hub/models--google--gemma-3-12b-it/snapshots/96b6f1eccf38110c56df3a15bffe176da04bfd80 \
    --height 288 --width 512 \
    --duration 30 --fps 24 \
    --steps 8 --model-variant distilled \
    --generate-audio --low-memory --seed 42 \
    --output /Users/Shared/huggingface/output/ltx_$(date +%Y%m%d_%H%M%S).mp4
```